### PR TITLE
Session/4

### DIFF
--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -4,7 +4,7 @@ import 'package:flutter_training/view/weather_view/weather_page.dart';
 import 'package:go_router/go_router.dart';
 
 mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
-  void afterDisplayLayout() {}
+  void afterDisplayLayout();
 
   @override
   void initState() {
@@ -39,7 +39,6 @@ class _LaunchViewState extends State<LaunchView> with AfterDisplayLayoutMixin {
 
   @override
   void afterDisplayLayout() {
-    
     _toWeatherView();
   }
 

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -3,6 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_training/view/weather_view/weather_page.dart';
 import 'package:go_router/go_router.dart';
 
+mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
+  void transitScreen() {}
+
+  void afterDisplayLayout() {
+    WidgetsBinding.instance.endOfFrame.then((_) {
+      transitScreen();
+    });
+  }
+}
+
 class LaunchView extends StatefulWidget {
   const LaunchView({super.key});
 
@@ -12,7 +22,7 @@ class LaunchView extends StatefulWidget {
   State<LaunchView> createState() => _LaunchViewState();
 }
 
-class _LaunchViewState extends State<LaunchView> {
+class _LaunchViewState extends State<LaunchView> with AfterDisplayLayoutMixin {
   Future<void> _toWeatherView() async {
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!mounted) {
@@ -23,12 +33,17 @@ class _LaunchViewState extends State<LaunchView> {
   }
 
   @override
+  void transitScreen() {
+    super.transitScreen();
+
+    _toWeatherView();
+  }
+
+  @override
   void initState() {
     super.initState();
 
-    WidgetsBinding.instance.endOfFrame.then((_) {
-      _toWeatherView();
-    });
+    afterDisplayLayout();
   }
 
   @override

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -11,9 +11,7 @@ mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
     super.initState();
 
     WidgetsBinding.instance.endOfFrame.then((_) {
-      if (mounted) {
         afterDisplayLayout();
-      }
     });
   }
 }

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -6,9 +6,14 @@ import 'package:go_router/go_router.dart';
 mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
   void transitScreen() {}
 
-  void afterDisplayLayout() {
+  @override
+  void initState() {
+    super.initState();
+
     WidgetsBinding.instance.endOfFrame.then((_) {
-      transitScreen();
+      if (mounted) {
+        transitScreen();
+      }
     });
   }
 }
@@ -37,13 +42,6 @@ class _LaunchViewState extends State<LaunchView> with AfterDisplayLayoutMixin {
     super.transitScreen();
 
     _toWeatherView();
-  }
-
-  @override
-  void initState() {
-    super.initState();
-
-    afterDisplayLayout();
   }
 
   @override

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -4,7 +4,7 @@ import 'package:flutter_training/view/weather_view/weather_page.dart';
 import 'package:go_router/go_router.dart';
 
 mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
-  void transitScreen() {}
+  void afterDisplayLayout() {}
 
   @override
   void initState() {
@@ -12,7 +12,7 @@ mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
 
     WidgetsBinding.instance.endOfFrame.then((_) {
       if (mounted) {
-        transitScreen();
+        afterDisplayLayout();
       }
     });
   }
@@ -38,9 +38,8 @@ class _LaunchViewState extends State<LaunchView> with AfterDisplayLayoutMixin {
   }
 
   @override
-  void transitScreen() {
-    super.transitScreen();
-
+  void afterDisplayLayout() {
+    
     _toWeatherView();
   }
 


### PR DESCRIPTION
## 課題

close #5 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->
- [x] レイアウトが表示された後に「何かしらの処理」を行う Mixin を作成する
  - AfterDisplayLayoutMixin を作成
- [x] 作成した Mixin の使用先で「何かしらの処理」を記述できるようにする
  - Mixinの使用先で override して利用する 関数の内容が未定義の transitScreen を実装
- [x] Session3 で作成した以下の処理を作成した Mixin を使って書き直す
- 新しい画面が表示されたら、0.5 秒後に前回まで作っていた画面に遷移する
  - Mixin で上記処理を実装した afterDisplayLayout メソッドを定義

## 動作


<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->

| expected | actual |
|----------|--------|
|    | <video width="300" src="https://user-images.githubusercontent.com/70502790/228181963-2628738a-8ce9-4388-b4e2-e2be54bb6a0d.mp4" />   |
