### PR TITLE
Session/7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,6 +1,10 @@
 targets:
   $default:
     builders:
+      source_gen|combining_builder:
+        options:
+          ignore_for_file:
+            - type=lint
       json_serializable:
         options:
           any_map: false

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,18 @@
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          any_map: false
+          checked: true
+          constructor: ""
+          create_factory: true
+          create_field_map: false
+          create_per_field_to_json: false
+          create_to_json: true
+          disallow_unrecognized_keys: false
+          explicit_to_json: false
+          field_rename: snake
+          generic_argument_factories: false
+          ignore_unannotated: false
+          include_if_null: true

--- a/build.yaml
+++ b/build.yaml
@@ -7,16 +7,5 @@ targets:
             - type=lint
       json_serializable:
         options:
-          any_map: false
           checked: true
-          constructor: ""
-          create_factory: true
-          create_field_map: false
-          create_per_field_to_json: false
-          create_to_json: true
-          disallow_unrecognized_keys: false
-          explicit_to_json: false
           field_rename: snake
-          generic_argument_factories: false
-          ignore_unannotated: false
-          include_if_null: true

--- a/lib/common/result.dart
+++ b/lib/common/result.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 part 'result.freezed.dart';
 
 @freezed

--- a/lib/model/weather/weather.dart
+++ b/lib/model/weather/weather.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/common/result.dart';
 import 'package:flutter_training/model/weather/weather_forecast_target.dart';

--- a/lib/model/weather/weather_forecast_target.dart
+++ b/lib/model/weather/weather_forecast_target.dart
@@ -1,4 +1,5 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 part 'weather_forecast_target.freezed.dart';
 part 'weather_forecast_target.g.dart';
 

--- a/lib/model/weather/weather_forecast_target.dart
+++ b/lib/model/weather/weather_forecast_target.dart
@@ -1,16 +1,14 @@
-class WeatherForecastTarget {
-  WeatherForecastTarget({
-    required this.area,
-    required this.date,
-  });
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'weather_forecast_target.freezed.dart';
+part 'weather_forecast_target.g.dart';
 
-  final String area;
-  final DateTime date;
+@freezed
+class WeatherForecastTarget with _$WeatherForecastTarget {
+  const factory WeatherForecastTarget({
+    required String area,
+    required DateTime date,
+  }) = _WeatherForecastTarget;
 
-  Map<String, dynamic> toJson() {
-    return {
-      'area': area,
-      'date': date.toString(),
-    };
-  }
+  factory WeatherForecastTarget.fromJson(Map<String, Object?> json) =>
+      _$WeatherForecastTargetFromJson(json);
 }

--- a/lib/model/weather/weather_forecast_target.freezed.dart
+++ b/lib/model/weather/weather_forecast_target.freezed.dart
@@ -1,0 +1,172 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_forecast_target.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+WeatherForecastTarget _$WeatherForecastTargetFromJson(
+    Map<String, dynamic> json) {
+  return _WeatherForecastTarget.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WeatherForecastTarget {
+  String get area => throw _privateConstructorUsedError;
+  DateTime get date => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WeatherForecastTargetCopyWith<WeatherForecastTarget> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WeatherForecastTargetCopyWith<$Res> {
+  factory $WeatherForecastTargetCopyWith(WeatherForecastTarget value,
+          $Res Function(WeatherForecastTarget) then) =
+      _$WeatherForecastTargetCopyWithImpl<$Res, WeatherForecastTarget>;
+  @useResult
+  $Res call({String area, DateTime date});
+}
+
+/// @nodoc
+class _$WeatherForecastTargetCopyWithImpl<$Res,
+        $Val extends WeatherForecastTarget>
+    implements $WeatherForecastTargetCopyWith<$Res> {
+  _$WeatherForecastTargetCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? area = null,
+    Object? date = null,
+  }) {
+    return _then(_value.copyWith(
+      area: null == area
+          ? _value.area
+          : area // ignore: cast_nullable_to_non_nullable
+              as String,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_WeatherForecastTargetCopyWith<$Res>
+    implements $WeatherForecastTargetCopyWith<$Res> {
+  factory _$$_WeatherForecastTargetCopyWith(_$_WeatherForecastTarget value,
+          $Res Function(_$_WeatherForecastTarget) then) =
+      __$$_WeatherForecastTargetCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String area, DateTime date});
+}
+
+/// @nodoc
+class __$$_WeatherForecastTargetCopyWithImpl<$Res>
+    extends _$WeatherForecastTargetCopyWithImpl<$Res, _$_WeatherForecastTarget>
+    implements _$$_WeatherForecastTargetCopyWith<$Res> {
+  __$$_WeatherForecastTargetCopyWithImpl(_$_WeatherForecastTarget _value,
+      $Res Function(_$_WeatherForecastTarget) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? area = null,
+    Object? date = null,
+  }) {
+    return _then(_$_WeatherForecastTarget(
+      area: null == area
+          ? _value.area
+          : area // ignore: cast_nullable_to_non_nullable
+              as String,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_WeatherForecastTarget implements _WeatherForecastTarget {
+  const _$_WeatherForecastTarget({required this.area, required this.date});
+
+  factory _$_WeatherForecastTarget.fromJson(Map<String, dynamic> json) =>
+      _$$_WeatherForecastTargetFromJson(json);
+
+  @override
+  final String area;
+  @override
+  final DateTime date;
+
+  @override
+  String toString() {
+    return 'WeatherForecastTarget(area: $area, date: $date)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_WeatherForecastTarget &&
+            (identical(other.area, area) || other.area == area) &&
+            (identical(other.date, date) || other.date == date));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, area, date);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_WeatherForecastTargetCopyWith<_$_WeatherForecastTarget> get copyWith =>
+      __$$_WeatherForecastTargetCopyWithImpl<_$_WeatherForecastTarget>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WeatherForecastTargetToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WeatherForecastTarget implements WeatherForecastTarget {
+  const factory _WeatherForecastTarget(
+      {required final String area,
+      required final DateTime date}) = _$_WeatherForecastTarget;
+
+  factory _WeatherForecastTarget.fromJson(Map<String, dynamic> json) =
+      _$_WeatherForecastTarget.fromJson;
+
+  @override
+  String get area;
+  @override
+  DateTime get date;
+  @override
+  @JsonKey(ignore: true)
+  _$$_WeatherForecastTargetCopyWith<_$_WeatherForecastTarget> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/weather/weather_forecast_target.g.dart
+++ b/lib/model/weather/weather_forecast_target.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// ignore_for_file: type=lint
+
+part of 'weather_forecast_target.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_WeatherForecastTarget _$$_WeatherForecastTargetFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_WeatherForecastTarget',
+      json,
+      ($checkedConvert) {
+        final val = _$_WeatherForecastTarget(
+          area: $checkedConvert('area', (v) => v as String),
+          date: $checkedConvert('date', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$_WeatherForecastTargetToJson(
+        _$_WeatherForecastTarget instance) =>
+    <String, dynamic>{
+      'area': instance.area,
+      'date': instance.date.toIso8601String(),
+    };

--- a/lib/model/weather/weather_info.dart
+++ b/lib/model/weather/weather_info.dart
@@ -1,48 +1,17 @@
 import 'package:flutter_training/model/weather/weather_condition.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+part 'weather_info.freezed.dart';
+part 'weather_info.g.dart';
 
-class WeatherInfo {
-  const WeatherInfo({
-    required this.weatherCondition,
-    required this.maxTemperature,
-    required this.minTemperature,
-    required this.date,
-  });
+@freezed
+class WeatherInfo with _$WeatherInfo {
+  const factory WeatherInfo({
+    required WeatherCondition weatherCondition,
+    required int maxTemperature,
+    required int minTemperature,
+    required DateTime date,
+  }) = _WeatherInfo;
 
-  factory WeatherInfo.fromJson(Map<String, dynamic> json) {
-    Never throwFormatException(String message) =>
-        throw FormatException(message);
-
-    final weatherCondition = WeatherCondition.values
-        .byNameOrNull(json['weather_condition'].toString());
-    if (weatherCondition == null) {
-      throwFormatException('weather_condition の値が適切ではありません。');
-    }
-
-    final maxTemperature = int.tryParse(json['max_temperature'].toString());
-    if (maxTemperature == null) {
-      throwFormatException('max_temperature の値が適切ではありません。');
-    }
-
-    final minTemperature = int.tryParse(json['min_temperature'].toString());
-    if (minTemperature == null) {
-      throwFormatException('min_temperature の値が適切ではありません。');
-    }
-
-    final date = json['date']?.toString();
-    if (date == null) {
-      throwFormatException('date の値が適切ではありません。');
-    }
-
-    return WeatherInfo(
-      weatherCondition: weatherCondition,
-      maxTemperature: maxTemperature,
-      minTemperature: minTemperature,
-      date: DateTime.parse(date),
-    );
-  }
-
-  final WeatherCondition weatherCondition;
-  final int maxTemperature;
-  final int minTemperature;
-  final DateTime date;
+  factory WeatherInfo.fromJson(Map<String, Object?> json) =>
+      _$WeatherInfoFromJson(json);
 }

--- a/lib/model/weather/weather_info.dart
+++ b/lib/model/weather/weather_info.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_training/model/weather/weather_condition.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+
 part 'weather_info.freezed.dart';
 part 'weather_info.g.dart';
 

--- a/lib/model/weather/weather_info.freezed.dart
+++ b/lib/model/weather/weather_info.freezed.dart
@@ -1,0 +1,219 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'weather_info.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+WeatherInfo _$WeatherInfoFromJson(Map<String, dynamic> json) {
+  return _WeatherInfo.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WeatherInfo {
+  WeatherCondition get weatherCondition => throw _privateConstructorUsedError;
+  int get maxTemperature => throw _privateConstructorUsedError;
+  int get minTemperature => throw _privateConstructorUsedError;
+  DateTime get date => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $WeatherInfoCopyWith<WeatherInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WeatherInfoCopyWith<$Res> {
+  factory $WeatherInfoCopyWith(
+          WeatherInfo value, $Res Function(WeatherInfo) then) =
+      _$WeatherInfoCopyWithImpl<$Res, WeatherInfo>;
+  @useResult
+  $Res call(
+      {WeatherCondition weatherCondition,
+      int maxTemperature,
+      int minTemperature,
+      DateTime date});
+}
+
+/// @nodoc
+class _$WeatherInfoCopyWithImpl<$Res, $Val extends WeatherInfo>
+    implements $WeatherInfoCopyWith<$Res> {
+  _$WeatherInfoCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? weatherCondition = null,
+    Object? maxTemperature = null,
+    Object? minTemperature = null,
+    Object? date = null,
+  }) {
+    return _then(_value.copyWith(
+      weatherCondition: null == weatherCondition
+          ? _value.weatherCondition
+          : weatherCondition // ignore: cast_nullable_to_non_nullable
+              as WeatherCondition,
+      maxTemperature: null == maxTemperature
+          ? _value.maxTemperature
+          : maxTemperature // ignore: cast_nullable_to_non_nullable
+              as int,
+      minTemperature: null == minTemperature
+          ? _value.minTemperature
+          : minTemperature // ignore: cast_nullable_to_non_nullable
+              as int,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_WeatherInfoCopyWith<$Res>
+    implements $WeatherInfoCopyWith<$Res> {
+  factory _$$_WeatherInfoCopyWith(
+          _$_WeatherInfo value, $Res Function(_$_WeatherInfo) then) =
+      __$$_WeatherInfoCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {WeatherCondition weatherCondition,
+      int maxTemperature,
+      int minTemperature,
+      DateTime date});
+}
+
+/// @nodoc
+class __$$_WeatherInfoCopyWithImpl<$Res>
+    extends _$WeatherInfoCopyWithImpl<$Res, _$_WeatherInfo>
+    implements _$$_WeatherInfoCopyWith<$Res> {
+  __$$_WeatherInfoCopyWithImpl(
+      _$_WeatherInfo _value, $Res Function(_$_WeatherInfo) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? weatherCondition = null,
+    Object? maxTemperature = null,
+    Object? minTemperature = null,
+    Object? date = null,
+  }) {
+    return _then(_$_WeatherInfo(
+      weatherCondition: null == weatherCondition
+          ? _value.weatherCondition
+          : weatherCondition // ignore: cast_nullable_to_non_nullable
+              as WeatherCondition,
+      maxTemperature: null == maxTemperature
+          ? _value.maxTemperature
+          : maxTemperature // ignore: cast_nullable_to_non_nullable
+              as int,
+      minTemperature: null == minTemperature
+          ? _value.minTemperature
+          : minTemperature // ignore: cast_nullable_to_non_nullable
+              as int,
+      date: null == date
+          ? _value.date
+          : date // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_WeatherInfo implements _WeatherInfo {
+  const _$_WeatherInfo(
+      {required this.weatherCondition,
+      required this.maxTemperature,
+      required this.minTemperature,
+      required this.date});
+
+  factory _$_WeatherInfo.fromJson(Map<String, dynamic> json) =>
+      _$$_WeatherInfoFromJson(json);
+
+  @override
+  final WeatherCondition weatherCondition;
+  @override
+  final int maxTemperature;
+  @override
+  final int minTemperature;
+  @override
+  final DateTime date;
+
+  @override
+  String toString() {
+    return 'WeatherInfo(weatherCondition: $weatherCondition, maxTemperature: $maxTemperature, minTemperature: $minTemperature, date: $date)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_WeatherInfo &&
+            (identical(other.weatherCondition, weatherCondition) ||
+                other.weatherCondition == weatherCondition) &&
+            (identical(other.maxTemperature, maxTemperature) ||
+                other.maxTemperature == maxTemperature) &&
+            (identical(other.minTemperature, minTemperature) ||
+                other.minTemperature == minTemperature) &&
+            (identical(other.date, date) || other.date == date));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, weatherCondition, maxTemperature, minTemperature, date);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_WeatherInfoCopyWith<_$_WeatherInfo> get copyWith =>
+      __$$_WeatherInfoCopyWithImpl<_$_WeatherInfo>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_WeatherInfoToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WeatherInfo implements WeatherInfo {
+  const factory _WeatherInfo(
+      {required final WeatherCondition weatherCondition,
+      required final int maxTemperature,
+      required final int minTemperature,
+      required final DateTime date}) = _$_WeatherInfo;
+
+  factory _WeatherInfo.fromJson(Map<String, dynamic> json) =
+      _$_WeatherInfo.fromJson;
+
+  @override
+  WeatherCondition get weatherCondition;
+  @override
+  int get maxTemperature;
+  @override
+  int get minTemperature;
+  @override
+  DateTime get date;
+  @override
+  @JsonKey(ignore: true)
+  _$$_WeatherInfoCopyWith<_$_WeatherInfo> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/model/weather/weather_info.g.dart
+++ b/lib/model/weather/weather_info.g.dart
@@ -1,5 +1,7 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
+// ignore_for_file: type=lint
+
 part of 'weather_info.dart';
 
 // **************************************************************************

--- a/lib/model/weather/weather_info.g.dart
+++ b/lib/model/weather/weather_info.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'weather_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_WeatherInfo _$$_WeatherInfoFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$_WeatherInfo',
+      json,
+      ($checkedConvert) {
+        final val = _$_WeatherInfo(
+          weatherCondition: $checkedConvert('weather_condition',
+              (v) => $enumDecode(_$WeatherConditionEnumMap, v)),
+          maxTemperature: $checkedConvert('max_temperature', (v) => v as int),
+          minTemperature: $checkedConvert('min_temperature', (v) => v as int),
+          date: $checkedConvert('date', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+      fieldKeyMap: const {
+        'weatherCondition': 'weather_condition',
+        'maxTemperature': 'max_temperature',
+        'minTemperature': 'min_temperature'
+      },
+    );
+
+Map<String, dynamic> _$$_WeatherInfoToJson(_$_WeatherInfo instance) =>
+    <String, dynamic>{
+      'weather_condition':
+          _$WeatherConditionEnumMap[instance.weatherCondition]!,
+      'max_temperature': instance.maxTemperature,
+      'min_temperature': instance.minTemperature,
+      'date': instance.date.toIso8601String(),
+    };
+
+const _$WeatherConditionEnumMap = {
+  WeatherCondition.sunny: 'sunny',
+  WeatherCondition.cloudy: 'cloudy',
+  WeatherCondition.rainy: 'rainy',
+};

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_training/view/weather_view/weather_page.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/view/launch_view.dart
+++ b/lib/view/launch_view.dart
@@ -11,7 +11,7 @@ mixin AfterDisplayLayoutMixin<T extends StatefulWidget> on State<T> {
     super.initState();
 
     WidgetsBinding.instance.endOfFrame.then((_) {
-        afterDisplayLayout();
+      afterDisplayLayout();
     });
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,7 +321,7 @@ packages:
     source: hosted
     version: "0.6.5"
   json_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: json_annotation
       sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -328,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
+  json_serializable:
+    dependency: "direct dev"
+    description:
+      name: json_serializable
+      sha256: dadc08bd61f72559f938dd08ec20dbfec6c709bba83515085ea943d2078d187a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   lints:
     dependency: transitive
     description:
@@ -461,6 +469,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.7"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "3b67aade1d52416149c633ba1bb36df44d97c6b51830c2198e934e3fca87ca1f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
   source_span:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_svg: ^2.0.4
   freezed_annotation: ^2.2.0
   go_router: ^6.5.0
+  json_annotation: ^4.8.0
   yumemi_weather:
     git:
       url: https://github.com/yumemi-inc/flutter-training-template.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   freezed: ^2.3.2
+  json_serializable: ^6.6.1
 
 flutter:
 


### PR DESCRIPTION
## 課題

close #8 

## 対応箇所

<!--
課題のどこに対応したか１つ１つ確認しましょう。
-->

- [x] json_serializable を利用して、独自のクラスから API のリクエストを作成する
  - 自動生成した `toJson` メソッドが、`jsonEncode` 内で呼ばれている 
- [x] json_serializable を利用して、API のレスポンスを独自のクラスに変換する

## 動作

<!--
画像や動画を添付しましょう。
動作に変更なければ、必要ありません。
-->


| expected | actual(iPhone 14Pro) | actual(Android Pixel6)|
|----------|--------|--------|
| <img src="https://user-images.githubusercontent.com/70502790/230830616-18a6318a-0443-46af-8711-e9dbee10aef1.gif" width="200"> | <video src="https://user-images.githubusercontent.com/70502790/230831199-851036de-7182-4ecd-b394-5375301e1e9c.mp4" width="200" /> | <img src="https://user-images.githubusercontent.com/70502790/230831063-56152b3d-a9ca-44a5-bf4c-c1c271bd78a9.gif" width="200"> |


## 備考
予期せぬ値がAPIから返ってきた際のテストもしましたが、正常にエラーハンドリングが行えていました。
- session6では一つ一つ丁寧にキャストエラーなどの対応もしていたので、`freezed, json_serializable`の便利さがよくわかりました！